### PR TITLE
feat/steps: allow trying one step at a time and getting expected number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,25 +47,28 @@ use termion::color;
 fn test_it(dif: u8, size: usize, nonce: [u8; 32]) {
     let create = Instant::now();
     let rp = ResourceProof::new(size, dif);
-    let data = &mut rp.create_proof_data(&nonce);
-    let proof = rp.create_proof(data);
+    let data = rp.create_proof_data(&nonce);
+    let mut prover = rp.create_prover(data.clone());
+    let expected_steps = prover.expected_steps();
+    let proof = prover.solve();
     let create_time = create.elapsed().as_secs();
     let check = Instant::now();
     if !rp.validate_proof(&nonce, proof) {
         println!("FAILED TO CONFIRM PROOF - POSSIBLE VIOLATION");
     }
 
-    if !rp.validate_data(&nonce, data) {
+    if !rp.validate_data(&nonce, &data) {
         println!("FAILED TO CONFIRM PROOF DATA - POSSIBLE VIOLATION");
     }
 
-    if !rp.validate_all(&nonce, data, proof) {
+    if !rp.validate_all(&nonce, &data, proof) {
         println!("FAILED TO CONFIRM PROOF & DATA - POSSIBLE VIOLATION");
     }
 
-    println!("Difficulty = {} size = {} create = {} seconds check = {} seconds num of attempts = \
-              {:?}",
+    println!("Difficulty = {} expected_steps = {} size = {} create = {} seconds check = {} \
+              seconds num of steps = {:?}",
              dif,
+             expected_steps,
              size,
              create_time,
              check.elapsed().as_secs(),


### PR DESCRIPTION
Motivation: we wish to do background resource proof in routing, and where a candidate fails the resource proof due to timeout (or other reason), we wish to be able to cancel any remaining jobs.

This is one way of solving that. I bumped the minor version number due to the API change. If you have any concerns I can try to find another approach.