### PR TITLE
Fix compiling against the target "x86_64-unknown-linux-musl"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "resource_proof"
 readme = "README.md"
 repository = "https://github.com/maidsafe/resource_proof"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 clap = "~2.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ rand = "~0.3.14"
 tiny-keccak = "~1.2.0"
 
 [target."cfg(unix)".dependencies]
-termion = "~1.1.1"
+termion = "1.3.0"


### PR DESCRIPTION
The dependency "termion" was breaking compilation with musl in previous versions, a fix a merged recently but is still present in the version used by this library.

Error produced:
```
[oleduc@bobdole resource_proof]$ cargo build --target=x86_64-unknown-linux-musl
   Compiling unicode-width v0.1.4
   Compiling unicode-segmentation v0.1.3
   Compiling libc v0.2.21
   Compiling strsim v0.5.2
   Compiling tiny-keccak v1.2.1
   Compiling ansi_term v0.9.0
   Compiling bitflags v0.7.0
   Compiling vec_map v0.6.0

   Compiling term_size v0.2.3
   Compiling termion v1.1.4
   Compiling rand v0.3.15
error[E0425]: cannot find function `tiocgwinsz` in this scope
  --> /home/oleduc/.cargo/registry/src/github.com-fdf3rr2333/termion-1.1.4/src/size.rs:57:33
   |
57 |         if ioctl(STDOUT_FILENO, tiocgwinsz(), &mut size as *mut _) == 0 {
   |                                 ^^^^^^^^^^ not found in this scope

   Compiling clap v2.14.1
error: aborting due to previous error

error: Could not compile `termion`.
Build failed, waiting for other jobs to finish...
```

After updating to 1.3.0
```
[oleduc@notbobdole resource_proof]$ cargo build --target=x86_64-unknown-linux-musl
 Downloading termion v1.3.0
   Compiling termion v1.3.0
   Compiling resource_proof v0.4.0 (file:///home/oleduc/Apps/resource_proof)
    Finished dev [unoptimized + debuginfo] target(s) in 2.44 secs
```


Test results:
```
[oleduc@bobdylan resource_proof]$ cargo test
   Compiling termion v1.3.0
   Compiling resource_proof v0.4.0 (file:///home/oleduc/Apps/resource_proof)
    Finished dev [unoptimized + debuginfo] target(s) in 2.49 secs
     Running target/debug/deps/resource_proof-bae262e7f6d4fc33

running 1 test
test tests::valid_proof ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

     Running target/debug/deps/resource_proof-fabe981fdfd6aa99

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests resource_proof

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

Test run:
```
[oleduc@maybebobdole release]$ ./resource_proof --difficulty 1 --size 1024 -i


Running analysis ....
Difficulty = 1 expected_steps = 2 size = 1024 create = 0 seconds check = 0 seconds num of steps = 0
Difficulty = 2 expected_steps = 4 size = 1024 create = 0 seconds check = 0 seconds num of steps = 0
Difficulty = 3 expected_steps = 8 size = 1024 create = 0 seconds check = 0 seconds num of steps = 0
Difficulty = 4 expected_steps = 16 size = 1024 create = 0 seconds check = 0 seconds num of steps = 0
Difficulty = 5 expected_steps = 32 size = 1024 create = 0 seconds check = 0 seconds num of steps = 9
Difficulty = 6 expected_steps = 64 size = 1024 create = 0 seconds check = 0 seconds num of steps = 9
Difficulty = 7 expected_steps = 128 size = 1024 create = 0 seconds check = 0 seconds num of steps = 9
Difficulty = 8 expected_steps = 256 size = 1024 create = 0 seconds check = 0 seconds num of steps = 9
Difficulty = 9 expected_steps = 512 size = 1024 create = 0 seconds check = 0 seconds num of steps = 9
Difficulty = 10 expected_steps = 1024 size = 1024 create = 0 seconds check = 0 seconds num of steps = 1567
Difficulty = 11 expected_steps = 2048 size = 1024 create = 0 seconds check = 0 seconds num of steps = 1653
Difficulty = 12 expected_steps = 4096 size = 1024 create = 0 seconds check = 0 seconds num of steps = 1653
Difficulty = 13 expected_steps = 8192 size = 1024 create = 0 seconds check = 0 seconds num of steps = 10488
Difficulty = 14 expected_steps = 16384 size = 1024 create = 0 seconds check = 0 seconds num of steps = 10488
Difficulty = 15 expected_steps = 32768 size = 1024 create = 11 seconds check = 0 seconds num of steps = 68122
```
