### PR TITLE
Update tiny-keccak from 1.5.0 to 2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ edition = "2018"
 [dependencies]
 clap = "~2.33.0"
 rand = "~0.4.1"
-tiny-keccak = "~1.5.0"
+
+  [dependencies.tiny-keccak]
+  version = "2.0.2"
+  features = [ "sha3" ]
 
 [target."cfg(unix)".dependencies]
 termion = "~1.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 #[cfg(test)]
 extern crate rand;
 use std::collections::VecDeque;
-use tiny_keccak::Keccak;
+use tiny_keccak::{Hasher, Sha3};
 
 /// Holds the prover requirements
 pub struct ResourceProof {
@@ -198,11 +198,11 @@ impl ResourceProver {
 
 /// Simple wrapper around tiny-keccak for use with deques
 fn hash(data: &(&[u8], &[u8])) -> [u8; 32] {
-    let mut sha3 = Keccak::new_sha3_256();
-    sha3.update(data.0);
-    sha3.update(data.1);
+    let mut hasher = Sha3::v256();
     let mut res = [0u8; 32];
-    sha3.finalize(&mut res);
+    hasher.update(data.0);
+    hasher.update(data.1);
+    hasher.finalize(&mut res);
     res
 }
 


### PR DESCRIPTION
In sn_node the vast majority of dependencies use tiny-keccak 2.0.2 so it makes sense to have them all at the same version.

```
sn_node (master) $  cargo tree -i tiny-keccak:1.5.0
tiny-keccak v1.5.0
├── resource_proof v0.8.0
│   └── sn_routing v0.42.0
│       └── sn_node v0.26.8 (/tmp/sn_node)
├── sn_data_types v0.14.0
│   ├── sn_messaging v3.0.0
│   │   ├── sn_node v0.26.8 (/tmp/sn_node)
│   │   └── sn_routing v0.42.0 (*)
│   ├── sn_node v0.26.8 (/tmp/sn_node)
│   └── sn_transfers v0.3.0
│       └── sn_node v0.26.8 (/tmp/sn_node)
└── sn_node v0.26.8 (/tmp/sn_node)

sn_node (master) $  cargo tree -i tiny-keccak:2.0.2
tiny-keccak v2.0.2
├── bls_signature_aggregator v0.1.6
│   └── sn_routing v0.42.0
│       └── sn_node v0.26.8 (/tmp/sn_node)
├── const-random-macro v0.1.13 (proc-macro)
│   └── const-random v0.1.13
│       └── ahash v0.3.8
│           └── dashmap v3.11.10
│               └── sn_node v0.26.8 (/tmp/sn_node)
├── sn_messaging v3.0.0
│   ├── sn_node v0.26.8 (/tmp/sn_node)
│   └── sn_routing v0.42.0 (*)
├── sn_routing v0.42.0 (*)
└── threshold_crypto v0.4.0
    ├── bls_dkg v0.3.3
    │   └── sn_routing v0.42.0 (*)
    ├── bls_signature_aggregator v0.1.6 (*)
    ├── sn_data_types v0.14.0
    │   ├── sn_messaging v3.0.0 (*)
    │   ├── sn_node v0.26.8 (/tmp/sn_node)
    │   └── sn_transfers v0.3.0
    │       └── sn_node v0.26.8 (/tmp/sn_node)
    ├── sn_messaging v3.0.0 (*)
    ├── sn_node v0.26.8 (/tmp/sn_node)
    ├── sn_routing v0.42.0 (*)
    └── sn_transfers v0.3.0 (*)
```